### PR TITLE
Added link to Java implementation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,6 +78,11 @@
             in Ruby
           </a>
 
+          <a href="https://github.com/jamsesso/json-logic-java" class="button">
+            <small>Parse JsonLogic</small>
+            in Java
+          </a>
+
           <p class="repo-owner"><a href="https://github.com/jwadhams/json-logic">json-logic</a> is maintained by <a href="https://github.com/jwadhams">Jeremy Wadhams</a>.</p>
 
           <p class="repo-owner">Thanks to <a href="https://thenounproject.com/adamparry/">Adam Parry</a> for the outstanding Vulcan Salute used in the logo, available on <a href="https://thenounproject.com/search/?q=spock&i=143495">The Noun Project</a>.</p>


### PR DESCRIPTION
I've added an implementation of json-logic in Java, passing all of the tests in the fixture file: http://jsonlogic.com/tests.json (tests: https://github.com/jamsesso/json-logic-java/blob/master/src/test/java/io/github/jamsesso/jsonlogic/FixtureTests.java)

Let me know if the implementation is missing anything in terms of documentation, etc.