### PR TITLE
Add tests for logic in arrays

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -217,6 +217,10 @@
     [{"if":[true, "apple", true, "banana", false, "carrot", "date"]}, null, "apple"],
     [{"if":[true, "apple", true, "banana", true, "carrot", "date"]}, null, "apple"],
 
+    "Arrays with logic",
+    [[1, {"var": "x"}, 3], {"x": 2}, [1, 2, 3]],
+    [{"if": [{"var": "x"}, [{"var": "y"}], 99]}, {"x": true, "y": 42}, [42]],
+
     "# Compound Tests",
     [ {"and":[{">":[3,1]},true]}, {}, true ],
     [ {"and":[{">":[3,1]},false]}, {}, false ],


### PR DESCRIPTION
This extends test suite with cases where logic is included in the array. The Ruby implementation does not handle those cases correctly right now, but the fix was already [submitted](https://github.com/bhgames/json-logic-ruby/pull/9).

It would be good to have those cases in the test suite, so other implementations can be tested against it.