### PR TITLE
added json-everything for a .Net implementation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,6 +78,11 @@
             in Ruby
           </a>
 
+          <a href="https://github.com/gregsdennis/json-everything" class="button">
+            <small>Parse JsonLogic</small>
+            in .Net
+          </a>
+
           <p class="repo-owner"><a href="https://github.com/jwadhams/json-logic">json-logic</a> is maintained by <a href="https://github.com/jwadhams">Jeremy Wadhams</a>.</p>
 
           <p class="repo-owner">Thanks to <a href="https://thenounproject.com/adamparry/">Adam Parry</a> for the outstanding Vulcan Salute used in the logo, available on <a href="https://thenounproject.com/search/?q=spock&i=143495">The Noun Project</a>.</p>


### PR DESCRIPTION
Happy to change the link to the Nuget package itself, but the others link to GH, so I did.

Funnily, the page build completed fine on my fork, but the publish failed because "jsonlogic.com is already taken."

Relates to https://github.com/jwadhams/json-logic-js/issues/93