### PR TITLE
Fix broken textarea auto size

### DIFF
--- a/example.js
+++ b/example.js
@@ -58,7 +58,13 @@ $(function(){
   $(".json-logic-example .apply").click(); //Run em all on page ready
 
   //Dynamically resize all the text areas
-  $(".json-logic-example textarea").textareaAutoSize();
+  $(".json-logic-example textarea").each(function () {
+    this.style.height = this.scrollHeight + "px";
+    this.style.overflowY = "hidden";
+  }).on("input", function () {
+    this.style.height = "auto";
+    this.style.height = this.scrollHeight + "px";
+  });
 
   $("body").on("click", ".json-logic-example .turn", function(event){
     $(event.target).closest(".json-logic-example")


### PR DESCRIPTION
The code is taken from https://stackoverflow.com/questions/454202/creating-a-textarea-with-auto-resize

Before and after on operators.html:
**Before**:
![before](https://github.com/user-attachments/assets/7f66736f-7480-486f-aa95-b616c77917d6)

**After**:
![after](https://github.com/user-attachments/assets/b933657d-9cc0-4c15-bb7f-970f48881fe9)

You can try this out online at https://json-logic.smankusors.com 

---

Btw, there's an alternative way without using JS, which is to use only CSS:
```
textarea {
   field-sizing: content;
}
```
However, as of now, it's only available on Chrome 123 and newer, so I think it's too new for us to use.
